### PR TITLE
refactor: remove obsolete SDK configuration for ESP32_GENERIC

### DIFF
--- a/boards/STRIPALERTS/mpconfigboard.cmake
+++ b/boards/STRIPALERTS/mpconfigboard.cmake
@@ -5,6 +5,5 @@ set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.ble
-    boards/ESP32_GENERIC/sdkconfig.board
     ${MICROPY_BOARD_DIR}/sdkconfig.board
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted SDK configuration defaults for the STRIPALERTS board to use only essential configuration presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->